### PR TITLE
[FIX] fix bug with standard emails sending

### DIFF
--- a/mail_statistics_extras/models/mail_mail.py
+++ b/mail_statistics_extras/models/mail_mail.py
@@ -31,4 +31,4 @@ class MailMail(osv.Model):
                     'email_to': ';'.join(email_list),
                     'subject': mail.subject,
                 })
-        return mail
+        return mail_id


### PR DESCRIPTION
When installing mail_statistics_extras, we cannot send standard emails anymore

There was a typo, here is the fix
